### PR TITLE
Implement double booking prevention

### DIFF
--- a/Application/Interfaces/IEventService.cs
+++ b/Application/Interfaces/IEventService.cs
@@ -11,4 +11,11 @@ public interface IEventService
     Task<EventDto?> UpdateEventAsync(Guid id, CreateEventDto updateEventDto);
     Task<bool> DeleteEventAsync(Guid id);
     Task<IEnumerable<EventDto>> GetEventsByDateRangeAsync(DateTime startDate, DateTime endDate);
+    Task<bool> HasConflictAsync(
+        DateTime startTime,
+        DateTime endTime,
+        string location,
+        string locationRoom,
+        Guid? excludeEventId = null
+    );
 }

--- a/Application/Services/EventService.cs
+++ b/Application/Services/EventService.cs
@@ -44,6 +44,22 @@ public class EventService : IEventService
 
     public async Task<EventDto?> CreateEventAsync(CreateEventDto createEventDto)
     {
+        // Check for conflicts before creating the event
+        var hasConflict = await HasConflictAsync(
+            createEventDto.StartTime,
+            createEventDto.EndTime,
+            createEventDto.Location,
+            createEventDto.LocationRoom
+        );
+
+        if (hasConflict)
+        {
+            // Return null to indicate failure due to conflict
+            // In a real application, you might want to throw a specific exception
+            // or return a more detailed result object
+            return null;
+        }
+
         var eventEntity = new EventEntity
         {
             Title = createEventDto.Title,
@@ -63,6 +79,23 @@ public class EventService : IEventService
         var existingResult = await _eventRepository.GetByIdAsync(id);
         if (!existingResult.IsSuccess || existingResult.Data == null)
         {
+            return null;
+        }
+
+        // Check for conflicts before updating the event, excluding the current event
+        var hasConflict = await HasConflictAsync(
+            updateEventDto.StartTime,
+            updateEventDto.EndTime,
+            updateEventDto.Location,
+            updateEventDto.LocationRoom,
+            id // Exclude the current event from conflict check
+        );
+
+        if (hasConflict)
+        {
+            // Return null to indicate failure due to conflict
+            // In a real application, you might want to throw a specific exception
+            // or return a more detailed result object
             return null;
         }
 
@@ -96,6 +129,25 @@ public class EventService : IEventService
         }
 
         return result.Data.Select(MapToDto);
+    }
+
+    public async Task<bool> HasConflictAsync(
+        DateTime startTime,
+        DateTime endTime,
+        string location,
+        string locationRoom,
+        Guid? excludeEventId = null
+    )
+    {
+        var result = await _eventRepository.GetConflictingEventsAsync(
+            startTime,
+            endTime,
+            location,
+            locationRoom,
+            excludeEventId
+        );
+
+        return result.IsSuccess && result.Data != null && result.Data.Any();
     }
 
     private static EventDto MapToDto(EventEntity entity)

--- a/Persistence/Interfaces/IEventRepository.cs
+++ b/Persistence/Interfaces/IEventRepository.cs
@@ -10,4 +10,11 @@ public interface IEventRepository : IBaseRepository<EventEntity>
         DateTime startDate,
         DateTime endDate
     );
+    Task<RepositoryResult<IEnumerable<EventEntity>>> GetConflictingEventsAsync(
+        DateTime startTime,
+        DateTime endTime,
+        string location,
+        string locationRoom,
+        Guid? excludeEventId = null
+    );
 }

--- a/README.md
+++ b/README.md
@@ -1,130 +1,68 @@
-# EventService - Gym Booking System
+# EventService
 
-A clean architecture .NET 9.0 API for managing gym events and bookings.
+A .NET 9.0 Web API for managing events with double booking prevention.
 
-## 🏗️ Architecture
+## ✨ Features
 
-- **Presentation Layer** - ASP.NET Core Web API
-- **Application Layer** - Business logic and DTOs
-- **Persistence Layer** - Entity Framework Core with SQLite
+- **Event Management** - Create, read, update, and delete events
+- **Double Booking Prevention** - Automatically prevents conflicting bookings in the same location and room
+- **Time-based Filtering** - Get upcoming events and events by date range
+- **Clean Architecture** - Separation of concerns with Application, Persistence, and Presentation layers
 
-## 🚀 Getting Started
+## 🚀 Quick Start
 
 ### Prerequisites
 
 - .NET 9.0 SDK
-- Your favorite IDE (Rider, Visual Studio, VS Code)
 
-### Setup
+### Run the API
 
-1. **Clone the repository**
+```bash
+git clone <your-repo-url>
+cd EventService
+dotnet restore
+dotnet run --project Presentation
+```
 
-   ```bash
-   git clone <your-repo-url>
-   cd EventService
-   ```
-
-2. **Configure settings**
-
-   ```bash
-   # Copy template files
-   cp Presentation/appsettings.template.json Presentation/appsettings.json
-   cp Presentation/appsettings.Development.template.json Presentation/appsettings.Development.json
-   ```
-
-3. **Restore packages**
-
-   ```bash
-   dotnet restore
-   ```
-
-4. **Run migrations**
-
-   ```bash
-   cd Presentation
-   dotnet ef database update
-   ```
-
-5. **Run the application**
-   ```bash
-   dotnet run --urls="http://localhost:5001"
-   ```
+The API will be available at `http://localhost:5000` with Swagger documentation at `/swagger`.
 
 ## 📚 API Endpoints
 
-### Events
+| Method   | Endpoint                 | Description              |
+| -------- | ------------------------ | ------------------------ |
+| `GET`    | `/api/events`            | Get all events           |
+| `GET`    | `/api/events/upcoming`   | Get upcoming events      |
+| `GET`    | `/api/events/{id}`       | Get specific event       |
+| `POST`   | `/api/events`            | Create new event         |
+| `PUT`    | `/api/events/{id}`       | Update event             |
+| `DELETE` | `/api/events/{id}`       | Delete event             |
+| `GET`    | `/api/events/date-range` | Get events by date range |
 
-- `GET /api/events` - Get all events
-- `GET /api/events/upcoming` - Get upcoming events
-- `GET /api/events/{id}` - Get specific event
-- `POST /api/events` - Create new event
-- `PUT /api/events/{id}` - Update event
-- `DELETE /api/events/{id}` - Delete event
-- `GET /api/events/date-range` - Get events by date range
+## 🚫 Double Booking Prevention
 
-### Swagger Documentation
+The system automatically prevents double bookings by:
 
-- Available at: `http://localhost:5001/swagger`
+- Checking for time overlaps in the same location and room
+- Returning HTTP 409 Conflict when conflicts are detected
+- Excluding the current event when updating (allows extending/modifying existing events)
+
+### Conflict Rules
+
+- ✅ **Allowed**: Different rooms, same time
+- ✅ **Allowed**: Same room, different times (no overlap)
+- ❌ **Blocked**: Same room, overlapping times
 
 ## 🗄️ Database
 
-- **Type**: SQLite
-- **File**: `EventService.db` (auto-created)
-- **Migrations**: Located in `Presentation/Migrations/`
+- Uses SQLite with Entity Framework Core
+- Database file is auto-created as `EventService.db`
+- Run `dotnet ef database update` from the Presentation folder if needed
 
-### Sample Data
-
-The database includes 10 sample gym events covering various workout types.
-
-## 🔧 Configuration
-
-Configuration files are ignored by Git for security. Use the template files:
-
-- `appsettings.template.json` - Production template
-- `appsettings.Development.template.json` - Development template
-
-## 🏃‍♂️ Frontend Integration
-
-The API includes CORS configuration for frontend connections:
-
-- Allowed origins: `http://localhost:3000`, `http://localhost:5001`
-
-## 🛠️ Development
-
-### Project Structure
+## 🏗️ Project Structure
 
 ```
 EventService/
-├── Application/           # Business logic
-│   ├── DTOs/             # Data Transfer Objects
-│   ├── Interfaces/       # Service contracts
-│   └── Services/         # Business logic implementation
-├── Persistence/          # Data access
-│   ├── Contexts/         # EF Core DbContext
-│   ├── Entities/         # Database entities
-│   ├── Interfaces/       # Repository contracts
-│   ├── Models/           # Helper models
-│   └── Repositories/     # Data access implementation
-└── Presentation/         # Web API
-    ├── Controllers/      # API controllers
-    ├── Migrations/       # EF Core migrations
-    └── Properties/       # Launch settings
+├── Application/      # Business logic and DTOs
+├── Persistence/      # Database entities and repositories
+└── Presentation/     # Web API controllers
 ```
-
-### Adding New Migrations
-
-```bash
-cd Presentation
-dotnet ef migrations add <MigrationName>
-dotnet ef database update
-```
-
-## 🔐 Security Notes
-
-- Database files (`*.db`) are ignored by Git
-- Configuration files with sensitive data are ignored
-- GUIDs are used for entity IDs for security and uniqueness
-
-## 📝 License
-
-This project is for educational purposes as part of a group project assignment.


### PR DESCRIPTION
- Add GetConflictingEventsAsync method to EventRepository
- Add HasConflictAsync method to EventService
- Update CreateEventAsync to check for conflicts before creating
- Update UpdateEventAsync to check for conflicts before updating
- Add proper HTTP 409 Conflict responses in EventsController
- Update README with simplified structure and double booking info

Prevents overlapping events in same location and room with clear error messages.