### PR TITLE
Add Trainer, Location and Room IDs to Events

### DIFF
--- a/Application/DTOs/CreateEventDto.cs
+++ b/Application/DTOs/CreateEventDto.cs
@@ -18,13 +18,13 @@ public class CreateEventDto
     public DateTime EndTime { get; set; }
 
     [Required]
-    [StringLength(200, ErrorMessage = "Location cannot be longer than 200 characters.")]
-    public string Location { get; set; } = null!;
-
-    [StringLength(100, ErrorMessage = "Location room cannot be longer than 100 characters.")]
-    public string LocationRoom { get; set; } = null!;
+    [StringLength(100, ErrorMessage = "Location ID cannot be longer than 100 characters.")]
+    public string LocationId { get; set; } = null!;
 
     [Required]
-    [StringLength(200, ErrorMessage = "Trainer name cannot be longer than 200 characters.")]
-    public string TrainerName { get; set; } = null!;
+    public int RoomId { get; set; }
+
+    [Required]
+    [StringLength(100, ErrorMessage = "Trainer ID cannot be longer than 100 characters.")]
+    public string TrainerId { get; set; } = null!;
 }

--- a/Application/DTOs/EventDto.cs
+++ b/Application/DTOs/EventDto.cs
@@ -7,7 +7,7 @@ public class EventDto
     public string Description { get; set; } = null!;
     public DateTime StartTime { get; set; }
     public DateTime EndTime { get; set; }
-    public string Location { get; set; } = null!;
-    public string LocationRoom { get; set; } = null!;
-    public string TrainerName { get; set; } = null!;
+    public string LocationId { get; set; } = null!;
+    public int RoomId { get; set; }
+    public string TrainerId { get; set; } = null!;
 }

--- a/Application/Interfaces/IEventService.cs
+++ b/Application/Interfaces/IEventService.cs
@@ -14,8 +14,8 @@ public interface IEventService
     Task<bool> HasConflictAsync(
         DateTime startTime,
         DateTime endTime,
-        string location,
-        string locationRoom,
+        string locationId,
+        int roomId,
         Guid? excludeEventId = null
     );
 }

--- a/Application/Services/EventService.cs
+++ b/Application/Services/EventService.cs
@@ -50,8 +50,9 @@ public class EventService : IEventService
             Description = createEventDto.Description,
             StartTime = createEventDto.StartTime,
             EndTime = createEventDto.EndTime,
-            Location = createEventDto.Location,
-            LocationRoom = createEventDto.LocationRoom,
+            LocationId = createEventDto.LocationId,
+            RoomId = createEventDto.RoomId,
+            TrainerId = createEventDto.TrainerId,
         };
 
         var result = await _eventRepository.AddAsync(eventEntity);
@@ -71,8 +72,9 @@ public class EventService : IEventService
         eventEntity.Description = updateEventDto.Description;
         eventEntity.StartTime = updateEventDto.StartTime;
         eventEntity.EndTime = updateEventDto.EndTime;
-        eventEntity.Location = updateEventDto.Location;
-        eventEntity.LocationRoom = updateEventDto.LocationRoom;
+        eventEntity.LocationId = updateEventDto.LocationId;
+        eventEntity.RoomId = updateEventDto.RoomId;
+        eventEntity.TrainerId = updateEventDto.TrainerId;
 
         var result = await _eventRepository.UpdateAsync(eventEntity);
         return result.IsSuccess && result.Data != null ? MapToDto(result.Data) : null;
@@ -101,16 +103,16 @@ public class EventService : IEventService
     public async Task<bool> HasConflictAsync(
         DateTime startTime,
         DateTime endTime,
-        string location,
-        string locationRoom,
+        string locationId,
+        int roomId,
         Guid? excludeEventId = null
     )
     {
         var result = await _eventRepository.GetConflictingEventsAsync(
             startTime,
             endTime,
-            location,
-            locationRoom,
+            locationId,
+            roomId,
             excludeEventId
         );
 
@@ -126,8 +128,9 @@ public class EventService : IEventService
             Description = entity.Description,
             StartTime = entity.StartTime,
             EndTime = entity.EndTime,
-            Location = entity.Location,
-            LocationRoom = entity.LocationRoom,
+            LocationId = entity.LocationId,
+            RoomId = entity.RoomId,
+            TrainerId = entity.TrainerId,
         };
     }
 }

--- a/Persistence/Entities/EventEntity.cs
+++ b/Persistence/Entities/EventEntity.cs
@@ -19,12 +19,12 @@ public class EventEntity
     [Required(ErrorMessage = "End time is required")]
     public DateTime EndTime { get; set; }
 
-    [Required(ErrorMessage = "Location is required")]
-    public string Location { get; set; } = null!;
+    [Required(ErrorMessage = "Location ID is required")]
+    public string LocationId { get; set; } = null!;
 
-    [Required(ErrorMessage = "Location room is required")]
-    public string LocationRoom { get; set; } = null!;
+    [Required(ErrorMessage = "Room ID is required")]
+    public int RoomId { get; set; }
 
-    [Required(ErrorMessage = "Trainer name is required")]
-    public string TrainerName { get; set; } = null!;
+    [Required(ErrorMessage = "Trainer ID is required")]
+    public string TrainerId { get; set; } = null!;
 }

--- a/Persistence/Interfaces/IEventRepository.cs
+++ b/Persistence/Interfaces/IEventRepository.cs
@@ -13,8 +13,8 @@ public interface IEventRepository : IBaseRepository<EventEntity>
     Task<RepositoryResult<IEnumerable<EventEntity>>> GetConflictingEventsAsync(
         DateTime startTime,
         DateTime endTime,
-        string location,
-        string locationRoom,
+        string locationId,
+        int roomId,
         Guid? excludeEventId = null
     );
 }

--- a/Persistence/Repositories/EventRepository.cs
+++ b/Persistence/Repositories/EventRepository.cs
@@ -55,15 +55,15 @@ public class EventRepository : BaseRepository<EventEntity>, IEventRepository
     public async Task<RepositoryResult<IEnumerable<EventEntity>>> GetConflictingEventsAsync(
         DateTime startTime,
         DateTime endTime,
-        string location,
-        string locationRoom,
+        string locationId,
+        int roomId,
         Guid? excludeEventId = null
     )
     {
         try
         {
             var query = _dbSet
-                .Where(e => e.Location == location && e.LocationRoom == locationRoom)
+                .Where(e => e.LocationId == locationId && e.RoomId == roomId)
                 .Where(e => e.StartTime < endTime && e.EndTime > startTime); // Overlap condition
 
             if (excludeEventId.HasValue)

--- a/Presentation/Controllers/EventsController.cs
+++ b/Presentation/Controllers/EventsController.cs
@@ -53,8 +53,8 @@ public class EventsController : ControllerBase
         var hasConflict = await _eventService.HasConflictAsync(
             createEventDto.StartTime,
             createEventDto.EndTime,
-            createEventDto.Location,
-            createEventDto.LocationRoom
+            createEventDto.LocationId,
+            createEventDto.RoomId
         );
 
         if (hasConflict)
@@ -88,8 +88,8 @@ public class EventsController : ControllerBase
         var hasConflict = await _eventService.HasConflictAsync(
             updateEventDto.StartTime,
             updateEventDto.EndTime,
-            updateEventDto.Location,
-            updateEventDto.LocationRoom,
+            updateEventDto.LocationId,
+            updateEventDto.RoomId,
             id
         );
 


### PR DESCRIPTION
## Description
Refactored Event entity to use ID-based references instead of string names for Location, Room, and Trainer.

Closes #72

## Changes Made
- ✅ Changed `Location` (string) → `LocationId` (string)
- ✅ Changed `LocationRoom` (string) → `RoomId` (int)
- ✅ Added `TrainerId` (string) for trainer reference
- ✅ Updated all DTOs (CreateEventDto, EventDto)
- ✅ Updated EventService with all mappings
- ✅ Updated EventRepository conflict checking logic
- ✅ Updated EventsController to use new fields
- ✅ Updated all interfaces (IEventService, IEventRepository)

## Files Changed
- `Persistence/Entities/EventEntity.cs`
- `Application/DTOs/CreateEventDto.cs`
- `Application/DTOs/EventDto.cs`
- `Application/Services/EventService.cs`
- `Application/Interfaces/IEventService.cs`
- `Persistence/Repositories/EventRepository.cs`
- `Persistence/Interfaces/IEventRepository.cs`
- `Presentation/Controllers/EventsController.cs`

## Testing
- [ ] Create database migration
- [ ] Test POST /api/events with new fields
- [ ] Test PUT /api/events/{id} with new fields
- [ ] Test GET endpoints return new fields
- [ ] Test conflict detection with LocationId and RoomId

## Type of Change
- [x] Refactoring
- [x] Breaking change (existing API contracts changed)

## Migration Required
⚠️ **Database migration required** - The database schema has changed and needs to be updated.